### PR TITLE
Remove hardcoded networks in HTTP routes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,11 +51,11 @@ app.use(promMid({
   requestDurationBuckets: [0.1, 0.5, 1, 1.5],
   metricsApp: metrics
 }))
-app.post('/:network(ithacanet|hangzhounet)', middlewareLogger((req: any, res: any) => popKeys(req, res)))
-app.get('/:network(ithacanet|hangzhounet)', middlewareLogger((req: any, res: any) => count(req, res)))
-app.post('/:network(ithacanet|hangzhounet)/ephemeral', middlewareLogger((req: any, res: any) => provisionEphemeralKey(req, res)))
-app.get('/:network(ithacanet|hangzhounet)/ephemeral/:id/keys/:key', middlewareLogger((req: any, res: any) => pk(req, res)))
-app.post('/:network(ithacanet|hangzhounet)/ephemeral/:id/keys/:key', middlewareLogger((req: any, res: any) => sign(req, res))) 
+app.post('/:network', middlewareLogger((req: any, res: any) => popKeys(req, res)))
+app.get('/:network', middlewareLogger((req: any, res: any) => count(req, res)))
+app.post('/:network/ephemeral', middlewareLogger((req: any, res: any) => provisionEphemeralKey(req, res)))
+app.get('/:network/ephemeral/:id/keys/:key', middlewareLogger((req: any, res: any) => pk(req, res)))
+app.post('/:network/ephemeral/:id/keys/:key', middlewareLogger((req: any, res: any) => sign(req, res))) 
 
 export const client: RedisClient = redis.createClient({
   host: config.redisHost,


### PR DESCRIPTION
# Summary
Currently when we want to run keygen on a new network we need to change the hardcoded HTTP routes in `src/index.ts` plus the configurations in `accounts-config.json` config file 

```json
{
  "taquito-example": {
    "hangzhounet": { 
      "regular": "taquito-example-hangzhounet",
      "ephemeral": "ephemeral-keys-hangzhounet"
    },
    "ithacanet": {
      "regular": "taquito-example-ithacanet",
      "ephemeral": "ephemeral-keys-ithacanet"
    }
  }
}
``` 

The hardcoded list of supported network in the source code seems redundant since every time we want to add support to a new network we need to issue a new Docker build. 

# Test Plan
Regression testing with and without hardcoded networks to confirm we still get the same behavior 

#### Before
Existing network
```bash
$ curl -i -H "Authorization: Bearer taquito-example" http://key-gen-1.i.tez.ie:3000/hangzhounet
HTTP/1.1 200 OK

{"balance":"80838479357","count":430}
```

Non existing network
```bash
$ curl -i -H "Authorization: Bearer taquito-example" http://key-gen-1.i.tez.ie:3000/non-existing
HTTP/1.1 404 Not Found

<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Cannot GET /non-existing</pre>
</body>
</html>
```

#### After
Existing network
```bash
$ curl -i -H "Authorization: Bearer dcp-staging" http://dcp-talentnet-keygen.i.tez.ie:3000/talentnet
HTTP/1.1 200 OK

{"balance":"58867604583","count":97}
```

Non existing network
```bash
$ curl -i -H "Authorization: Bearer dcp-staging" http://dcp-talentnet-keygen.i.tez.ie:3000/non-existing
HTTP/1.1 404 Not Found
```